### PR TITLE
Locale: Fix unexpected redirects + Don't search locale in cookies when `$cookieDuration` is null 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1 under development
 
-- no changes in this release.
+- Bug #96: Fix unexpected redirects from `Locale` middleware on GET requests (@vjik)
 
 ## 1.0.0 May 22, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1 under development
 
 - Bug #96: Fix unexpected redirects from `Locale` middleware on GET requests (@vjik)
+- Bug #97: Don't search locale in cookies when `$cookieDuration` is null (@vjik)
 
 ## 1.0.0 May 22, 2023
 

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -94,7 +94,7 @@ final class Locale implements MiddlewareInterface
             $queryParameters = $request->getQueryParams();
             $locale = $this->getLocaleFromQuery($queryParameters);
 
-            if ($locale === null) {
+            if ($locale === null && $this->cookieDuration !== null) {
                 /** @psalm-var array<string, string> $cookieParameters */
                 $cookieParameters = $request->getCookieParams();
                 $locale = $this->getLocaleFromCookies($cookieParameters);

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -84,7 +84,10 @@ final class Locale implements MiddlewareInterface
 
         if ($locale !== null) {
             if ($locale === $this->defaultLocale && $request->getMethod() === Method::GET) {
-                return $this->createRedirectResponse(substr($path, strlen($locale) + 1) ?: '/', $query);
+                return $this->saveLocale(
+                    $locale,
+                    $this->createRedirectResponse(substr($path, strlen($locale) + 1) ?: '/', $query)
+                );
             }
         } else {
             /** @psalm-var array<string, string> $queryParameters */

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -109,6 +109,23 @@ final class LocaleTest extends TestCase
         $this->assertSame('en', $cookies['_language']->getValue());
     }
 
+    public function testDefaultLocaleDoNotSaveToCookie(): void
+    {
+        $request = $this->createRequest('/home?test=1');
+
+        $middleware = $this->createMiddleware(
+            locales: ['en' => 'en-US', 'uz' => 'uz-UZ'],
+            cookieDuration: new DateInterval('P5D'),
+        );
+
+        $response = $this->process($middleware, $request);
+
+        $cookies = CookieCollection::fromResponse($response)->toArray();
+
+        $this->assertSame(Status::OK, $response->getStatusCode());
+        $this->assertEmpty($cookies);
+    }
+
     public function testLocaleFromPathDoesNotMatchDefaultLocale(): void
     {
         $uri = '/uz/home?test=1';

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -46,14 +46,14 @@ final class LocaleTest extends TestCase
         $this->lastRequest = null;
         $this->logger = new SimpleLogger();
 
-        if (str_starts_with($this->getName(), 'testSaveLocaleWithCustomArguments')) {
+        if (extension_loaded('uopz') && str_starts_with($this->getName(), 'testSaveLocaleWithCustomArguments')) {
             ClockMock::freeze(new DateTime('2023-05-10 08:24:39'));
         }
     }
 
     public function tearDown(): void
     {
-        if (str_starts_with($this->getName(), 'testSaveLocaleWithCustomArguments')) {
+        if (extension_loaded('uopz') && str_starts_with($this->getName(), 'testSaveLocaleWithCustomArguments')) {
             ClockMock::reset();
         }
     }
@@ -288,6 +288,10 @@ final class LocaleTest extends TestCase
      */
     public function testSaveLocaleWithCustomArguments(?string $cookieName, ?bool $secureCookie): void
     {
+        if (!extension_loaded('uopz')) {
+            $this->markTestSkipped('No uopz extension available. Skipping.');
+        }
+
         $request = $this->createRequest('/uz');
         $middleware = $this
             ->createMiddleware(['uz' => 'uz-UZ'], saveToSession: true)

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -511,7 +511,18 @@ final class LocaleTest extends TestCase
         $this->assertSame(Status::OK, $response->getStatusCode());
     }
 
-    public function testIgnoredRequests(): void
+    public function testIgnoredRequest(): void
+    {
+        $request = $this->createRequest($uri = '/auth/login');
+        $middleware = $this->createMiddleware(['uz' => 'uz-UZ'])->withIgnoredRequestUrlPatterns(['/auth/**']);
+
+        $response = $this->process($middleware, $request);
+
+        $this->assertSame($uri, $this->getRequestPath());
+        $this->assertSame(Status::OK, $response->getStatusCode());
+    }
+
+    public function testIgnoredRequestWithLocaleInQueryParams(): void
     {
         $request = $this->createRequest($uri = '/auth/login', queryParams: ['_language' => 'uz']);
         $middleware = $this->createMiddleware(['uz' => 'uz-UZ'])->withIgnoredRequestUrlPatterns(['/auth/**']);

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -415,7 +415,7 @@ final class LocaleTest extends TestCase
         );
         $response = $this->process($middleware, $request);
 
-        $this->assertSame("/uz/", $response->getHeaderLine(Header::LOCATION));
+        $this->assertSame('/uz/', $response->getHeaderLine(Header::LOCATION));
         $this->assertSame(Status::FOUND, $response->getStatusCode());
     }
 

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -511,18 +511,7 @@ final class LocaleTest extends TestCase
         $this->assertSame(Status::OK, $response->getStatusCode());
     }
 
-    public function testIgnoredRequest(): void
-    {
-        $request = $this->createRequest($uri = '/auth/login');
-        $middleware = $this->createMiddleware(['uz' => 'uz-UZ'])->withIgnoredRequestUrlPatterns(['/auth/**']);
-
-        $response = $this->process($middleware, $request);
-
-        $this->assertSame($uri, $this->getRequestPath());
-        $this->assertSame(Status::OK, $response->getStatusCode());
-    }
-
-    public function testIgnoredRequestWithLocaleInQueryParams(): void
+    public function testIgnoredRequests(): void
     {
         $request = $this->createRequest($uri = '/auth/login', queryParams: ['_language' => 'uz']);
         $middleware = $this->createMiddleware(['uz' => 'uz-UZ'])->withIgnoredRequestUrlPatterns(['/auth/**']);

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -337,7 +337,10 @@ final class LocaleTest extends TestCase
      */
     public function testLocaleFromCookies(?string $parameterName): void
     {
-        $middleware = $this->createMiddleware(['uz' => 'uz-UZ', 'en' => 'en-US']);
+        $middleware = $this->createMiddleware(
+            locales: ['uz' => 'uz-UZ', 'en' => 'en-US'],
+            cookieDuration: new DateInterval('P5D'),
+        );
         if ($parameterName !== null) {
             $middleware = $middleware->withCookieName($parameterName);
         }

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -398,10 +398,7 @@ final class LocaleTest extends TestCase
         $this->assertSame($expectedLoggerMessages, $this->logger->getMessages());
     }
 
-    /**
-     * Locale from query params has a higher priority than from cookies.
-     */
-    public function testLocaleFromQueryParamWithCookie(): void
+    public function testLocaleFromQueryParamPriorityOverCookie(): void
     {
         $middleware = $this->createMiddleware(
             locales: ['uz' => 'uz-UZ', 'ru' => 'ru-RU'],

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -398,6 +398,27 @@ final class LocaleTest extends TestCase
         $this->assertSame($expectedLoggerMessages, $this->logger->getMessages());
     }
 
+    /**
+     * Locale from query params has a higher priority than from cookies.
+     */
+    public function testLocaleFromQueryParamWithCookie(): void
+    {
+        $middleware = $this->createMiddleware(
+            locales: ['uz' => 'uz-UZ', 'ru' => 'ru-RU'],
+            cookieDuration: new DateInterval('P5D'),
+        );
+
+        $request = $this->createRequest(
+            '/',
+            queryParams: ['_language' => 'uz'],
+            cookieParams: ['_language' => 'ru']
+        );
+        $response = $this->process($middleware, $request);
+
+        $this->assertSame("/uz/", $response->getHeaderLine(Header::LOCATION));
+        $this->assertSame(Status::FOUND, $response->getStatusCode());
+    }
+
     public function dataDetectLocale(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #96 