### PR TITLE
[Example] Add example for handling errors

### DIFF
--- a/src/CorsAllowAll.php
+++ b/src/CorsAllowAll.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\ErrorHandler\HeadersProvider;
 use Yiisoft\Http\Header;
 
 /**
@@ -15,8 +16,20 @@ use Yiisoft\Http\Header;
  */
 final class CorsAllowAll implements MiddlewareInterface
 {
+    public function __construct(
+        private HeadersProvider $headersProvider
+    ) {
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $this->headersProvider->add(Header::ACCESS_CONTROL_ALLOW_ORIGIN, '*');
+        $this->headersProvider->add(Header::ACCESS_CONTROL_ALLOW_METHODS, 'GET,OPTIONS,HEAD,POST,PUT,PATCH,DELETE');
+        $this->headersProvider->add(Header::ACCESS_CONTROL_ALLOW_HEADERS, '*');
+        $this->headersProvider->add(Header::ACCESS_CONTROL_EXPOSE_HEADERS, '*');
+        $this->headersProvider->add(Header::ACCESS_CONTROL_ALLOW_CREDENTIALS, 'true');
+        $this->headersProvider->add(Header::ACCESS_CONTROL_MAX_AGE, '86400');
+
         $response = $handler->handle($request);
 
         return $response


### PR DESCRIPTION
I think the middleware should handle also all errors cases, when `response` is not ready because of an exception