### PR TITLE
Remove `uopz` dependency by PSR-20 clock interface usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.5 under development
 
-- no changes in this release.
+- Chg #130: Bump minimal version of `yiisoft/cookie` to `^1.2.3` (@vjik)
+- Enh #130: Allow to use PSR-20 clock interface to get current time into `Locale` middleware (@vjik)
 
 ## 1.0.4 September 03, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "yiisoft/aliases": "^3.0",
-        "yiisoft/cookies": "^1.2",
+        "yiisoft/cookies": "^1.2.3",
         "yiisoft/friendly-exception": "^1.0",
         "yiisoft/http": "^1.2",
         "yiisoft/network-utilities": "^1.2",
@@ -47,13 +47,12 @@
         "yiisoft/validator": "^1.0|^2.0"
     },
     "require-dev": {
-        "ext-uopz": "*",
         "httpsoft/http-message": "^1.0",
         "maglnet/composer-require-checker": "^4.2",
         "phpunit/phpunit": "^9.5",
+        "psr/clock": "^1.0",
         "rector/rector": "^1.2",
         "roave/infection-static-analysis-plugin": "^1.16",
-        "slope-it/clock-mock": "^0.3.6",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.30|^5.25",
         "yiisoft/router-fastroute": "^3.0",

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Middleware;
 
 use DateInterval;
 use InvalidArgumentException;
+use Psr\Clock\ClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -66,6 +67,7 @@ final class Locale implements MiddlewareInterface
         private array $ignoredRequestUrlPatterns = [],
         private bool $secureCookie = false,
         private ?DateInterval $cookieDuration = null,
+        private ?ClockInterface $clock = null,
     ) {
         $this->assertSupportedLocalesFormat($supportedLocales);
         $this->supportedLocales = $supportedLocales;
@@ -208,7 +210,12 @@ final class Locale implements MiddlewareInterface
         }
 
         $this->logger->debug('Saving found locale to cookies.');
-        $cookie = new Cookie(name: $this->cookieName, value: $locale, secure: $this->secureCookie);
+        $cookie = new Cookie(
+            name: $this->cookieName,
+            value: $locale,
+            secure: $this->secureCookie,
+            clock: $this->clock,
+        );
         $cookie = $cookie->withMaxAge($this->cookieDuration);
 
         return $cookie->addToResponse($response);

--- a/tests/Support/StaticClock.php
+++ b/tests/Support/StaticClock.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Middleware\Tests\Support;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class StaticClock implements ClockInterface
+{
+    public function __construct(
+        private DateTimeImmutable $now,
+    ) {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

