### PR TITLE
Mark `CorsAllowAll`, `ForceSecureConnection`, `HttpCache` and `TagRequest` middlewares as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #129: Explicitly mark nullable parameters (@dagpro)
 - Chg #130: Bump minimal version of `yiisoft/cookie` to `^1.2.3` (@vjik)
 - Enh #130: Allow to use PSR-20 clock interface to get current time into `Locale` middleware (@vjik)
+- Chg #132: Mark `CorsAllowAll`, `ForceSecureConnection`, `HttpCache` and `TagRequest` middlewares as deprecated (@vjik)
 
 ## 1.0.4 September 03, 2024
 

--- a/src/CorsAllowAll.php
+++ b/src/CorsAllowAll.php
@@ -12,6 +12,8 @@ use Yiisoft\Http\Header;
 
 /**
  * Adds Cross-Origin Resource Sharing (CORS) headers allowing everything to the response.
+ *
+ * @deprecated Use `CorsAllowAllMiddleware` from `yiisoft/http-middleware` package instead.
  */
 final class CorsAllowAll implements MiddlewareInterface
 {

--- a/src/ForceSecureConnection.php
+++ b/src/ForceSecureConnection.php
@@ -25,6 +25,8 @@ use function strcasecmp;
  *
  * Note: Prefer forcing HTTPS via web server in case you aren't creating installable product such as CMS and aren't
  * hosting the project on a server where you don't have access to web server configuration.
+ *
+ * @deprecated Use `ForceSecureConnectionMiddleware` from `yiisoft/http-middleware` package instead.
  */
 final class ForceSecureConnection implements MiddlewareInterface
 {

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -22,6 +22,8 @@ use function strtotime;
 
 /**
  * HttpCache implements client-side caching by utilizing the `Last-Modified` and `ETag` HTTP headers.
+ *
+ * @deprecated Use `HttpCacheMiddleware` from `yiisoft/http-middleware` package instead.
  */
 final class HttpCache implements MiddlewareInterface
 {

--- a/src/TagRequest.php
+++ b/src/TagRequest.php
@@ -13,6 +13,8 @@ use function uniqid;
 
 /**
  * Tags request with a random value that could be later used for identifying it.
+ *
+ * @deprecated Use `TagRequestMiddleware` from `yiisoft/http-middleware` package instead.
  */
 final class TagRequest implements MiddlewareInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

